### PR TITLE
Update accessoryDidDisconnectNotification

### DIFF
--- a/AdyenBarcoder/AccessoryStreamer.swift
+++ b/AdyenBarcoder/AccessoryStreamer.swift
@@ -168,8 +168,13 @@ class AccessoryStreamer: Streamer {
     @objc func accessoryDidDisconnectNotification(_ notification: NSNotification) {
         if let accessory = notification.userInfo?[EAAccessoryKey] as? EAAccessory {
             Logger.debug("Received accessoryDidDisconnectNotification with: \(accessory.description)")
-            deviceStatus = .disconnected
-            closeSession()
+            // Check the accessory was the Adyen device that disconnected. 
+            // If it was - close the session otherwise do nothing. If the e315 hasnt disconnected then
+            // the session should remain open
+            if(accessory.name.contains("PAYWare")){
+                deviceStatus = .disconnected
+                closeSession()
+            }           
         }
     }
 }


### PR DESCRIPTION
Modify the accessoryDidDisconnectNotification method to handle the case where the Adyen device was not the accessory that disconnected. 
If a bluetooth printer (or another EAAccessory) disconnects while using the e315m this method will close the session and the barcode scanning will no longer work.
